### PR TITLE
Add edgeR differential expression wrapper

### DIFF
--- a/R/run_edger.R
+++ b/R/run_edger.R
@@ -1,0 +1,18 @@
+runEdgeR <- function(object, design, contrast) {
+  counts <- SummarizedExperiment::assay(object, "counts")
+  y <- edgeR::DGEList(counts)
+  y <- edgeR::calcNormFactors(y)
+  fit <- edgeR::glmQLFit(y, design)
+  qlf <- edgeR::glmQLFTest(fit, contrast = contrast)
+  tab <- edgeR::topTags(qlf, n = Inf, sort.by = "none")$table
+  res <- S4Vectors::DataFrame(
+    logFC = tab$logFC,
+    PValue = tab$PValue,
+    FDR = tab$FDR,
+    row.names = rownames(tab)
+  )
+  results <- deResults(object)
+  results$edgeR <- res
+  deResults(object) <- results
+  invisible(object)
+}


### PR DESCRIPTION
## Summary
- add `runEdgeR` to fit GLM-QLF models with edgeR and save results

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6890c5e1f5dc8330a4e40bdffeef24de