### PR TITLE
Add limma and DESeq wrappers with edgeR-style columns

### DIFF
--- a/R/run_deseq.R
+++ b/R/run_deseq.R
@@ -1,0 +1,24 @@
+runDESeq <- function(object, design, contrast) {
+  counts <- SummarizedExperiment::assay(object, "counts")
+  col_data <- S4Vectors::DataFrame(design, row.names = colnames(counts))
+  formula <- stats::as.formula(
+    paste("~", paste(colnames(col_data), collapse = "+"))
+  )
+  dds <- DESeq2::DESeqDataSetFromMatrix(
+    countData = counts,
+    colData = col_data,
+    design = formula
+  )
+  dds <- DESeq2::DESeq(dds)
+  res_tab <- DESeq2::results(dds, contrast = contrast)
+  res <- S4Vectors::DataFrame(
+    logFC = res_tab$log2FoldChange,
+    PValue = res_tab$pvalue,
+    FDR = res_tab$padj,
+    row.names = rownames(res_tab)
+  )
+  results <- deResults(object)
+  results$DESeq <- res
+  deResults(object) <- results
+  invisible(object)
+}

--- a/R/run_limma.R
+++ b/R/run_limma.R
@@ -1,0 +1,18 @@
+runLimma <- function(object, design, contrast) {
+  counts <- SummarizedExperiment::assay(object, "counts")
+  v <- limma::voom(counts, design)
+  fit <- limma::lmFit(v, design)
+  fit <- limma::contrasts.fit(fit, contrast)
+  fit <- limma::eBayes(fit)
+  tab <- limma::topTable(fit, n = Inf, sort.by = "none")
+  res <- S4Vectors::DataFrame(
+    logFC = tab$logFC,
+    PValue = tab$P.Value,
+    FDR = tab$adj.P.Val,
+    row.names = rownames(tab)
+  )
+  results <- deResults(object)
+  results$limma <- res
+  deResults(object) <- results
+  invisible(object)
+}


### PR DESCRIPTION
## Summary
- add `runLimma()` wrapping voom + lmFit + eBayes and storing results with logFC, PValue, and FDR columns
- add `runDESeq()` wrapper around DESeq2::DESeq that outputs logFC, PValue, and FDR columns

## Testing
- `R -q -e "devtools::load_all()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6890c7210858833080b8b1b6b45a9e66