### PR TITLE
Implement utility helpers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,11 +19,12 @@ URL: https://github.com/icervenka/DESummarizedExperiment
 BugReports: https://github.com/icervenka/DESummarizedExperiment/issues
 Depends:
     R (>= 4.4)
-Imports: 
+Imports:
     dplyr,
     methods,
     S4Vectors,
-    SingleCellExperiment
+    SingleCellExperiment,
+    SummarizedExperiment
 Suggests:
     BiocStyle,
     knitr,

--- a/R/as_summarized_experiment.R
+++ b/R/as_summarized_experiment.R
@@ -1,0 +1,20 @@
+#' Coerce to SummarizedExperiment
+#'
+#' @param from A DESummarizedExperiment.
+#'
+#' @return A SummarizedExperiment.
+#' @export
+#' @importFrom SummarizedExperiment SummarizedExperiment assays rowData colData
+#' @importFrom S4Vectors metadata
+setAs(
+  "DESummarizedExperiment",
+  "SummarizedExperiment",
+  function(from) {
+    SummarizedExperiment::SummarizedExperiment(
+      assays = SummarizedExperiment::assays(from),
+      rowData = SummarizedExperiment::rowData(from),
+      colData = SummarizedExperiment::colData(from),
+      metadata = S4Vectors::metadata(from)
+    )
+  }
+)

--- a/R/export_results.R
+++ b/R/export_results.R
@@ -1,0 +1,27 @@
+#' Export DE and pathway results
+#'
+#' Write differential expression and pathway results to CSV files.
+#'
+#' @param x A DESummarizedExperiment.
+#' @param dir Directory to write results.
+#'
+#' @return Invisibly returns a character vector of file paths written.
+#' @export
+#' @importFrom utils write.csv
+exportResults <- function(x, dir) {
+  if (!dir.exists(dir)) {
+    dir.create(dir, recursive = TRUE)
+  }
+  paths <- character()
+  for (nm in names(x@deResults)) {
+    file <- file.path(dir, paste0(nm, ".csv"))
+    utils::write.csv(x@deResults[[nm]], file, row.names = TRUE)
+    paths <- c(paths, file)
+  }
+  for (nm in names(x@pathwayResults)) {
+    file <- file.path(dir, paste0(nm, ".csv"))
+    utils::write.csv(x@pathwayResults[[nm]], file, row.names = TRUE)
+    paths <- c(paths, file)
+  }
+  invisible(paths)
+}

--- a/R/import_de.R
+++ b/R/import_de.R
@@ -1,0 +1,20 @@
+#' Import DE results from files
+#'
+#' Read differential expression result files into a SimpleList.
+#'
+#' @param paths Character vector of file paths.
+#'
+#' @return A SimpleList of data frames.
+#' @export
+#' @importFrom utils read.csv
+#' @importFrom S4Vectors SimpleList
+importDE <- function(paths) {
+  files <- normalizePath(paths, mustWork = TRUE)
+  out <- lapply(files, utils::read.csv, stringsAsFactors = FALSE)
+  if (is.null(names(paths))) {
+    names(out) <- sub("\\.[^.]*$", "", basename(files))
+  } else {
+    names(out) <- names(paths)
+  }
+  S4Vectors::SimpleList(out)
+}

--- a/R/merge_desummarized_experiment.R
+++ b/R/merge_desummarized_experiment.R
@@ -1,0 +1,35 @@
+#' Merge DESummarizedExperiment objects
+#'
+#' Combine multiple DESummarizedExperiment objects column-wise.
+#'
+#' @param ... DESummarizedExperiment objects.
+#'
+#' @return A merged DESummarizedExperiment.
+#' @export
+#' @importFrom S4Vectors SimpleList metadata metadata<-
+#' @importFrom methods is validObject
+mergeDESummarizedExperiment <- function(...) {
+  objects <- list(...)
+  if (!length(objects)) {
+    stop("no objects supplied")
+  }
+  if (!all(vapply(objects, methods::is, logical(1), "DESummarizedExperiment"))) {
+    stop("all inputs must be DESummarizedExperiment objects")
+  }
+  row_ids <- rownames(objects[[1]])
+  same_rows <- vapply(objects[-1], function(x) identical(rownames(x), row_ids), logical(1))
+  if (!all(same_rows)) {
+    stop("all objects must have identical rownames")
+  }
+  merged <- do.call(cbind, objects)
+  merged@design <- NULL
+  merged@contrastList <- list()
+  merged@deResults <- S4Vectors::SimpleList()
+  merged@pathwayResults <- S4Vectors::SimpleList()
+  m <- S4Vectors::metadata(merged)
+  m$design <- NULL
+  m$de_results <- NULL
+  S4Vectors::metadata(merged) <- m
+  methods::validObject(merged)
+  merged
+}

--- a/R/subset_methods.R
+++ b/R/subset_methods.R
@@ -1,0 +1,80 @@
+#' Subsetting methods for DESummarizedExperiment
+#'
+#' Methods for `[`, `[[`, and `subset` that keep custom slots in sync.
+#'
+#' @name subsetting-methods
+#' @docType methods
+NULL
+
+#' @rdname subsetting-methods
+#' @importFrom S4Vectors endoapply
+#' @export
+setMethod(
+  "[",
+  "DESummarizedExperiment",
+  function(x, i, j, ..., drop = FALSE) {
+    y <- callNextMethod()
+    if (!missing(i)) {
+      y@deResults <- S4Vectors::endoapply(x@deResults, function(z) z[i, , drop = FALSE])
+      y@pathwayResults <- S4Vectors::endoapply(x@pathwayResults, function(z) z[i, , drop = FALSE])
+    } else {
+      y@deResults <- x@deResults
+      y@pathwayResults <- x@pathwayResults
+    }
+    if (!missing(j) && !is.null(x@design)) {
+      y@design <- x@design[j, , drop = FALSE]
+    } else {
+      y@design <- x@design
+    }
+    updateDEmetadata(y)
+  }
+)
+
+#' @rdname subsetting-methods
+#' @export
+setMethod(
+  "subset",
+  "DESummarizedExperiment",
+  function(x, subset, select, ...) {
+    callNextMethod()
+  }
+)
+
+#' @rdname subsetting-methods
+#' @export
+setMethod(
+  "[[",
+  "DESummarizedExperiment",
+  function(x, i, j, ...) {
+    if (!missing(i)) {
+      if (i %in% names(x@deResults)) {
+        return(x@deResults[[i]])
+      }
+      if (i %in% names(x@pathwayResults)) {
+        return(x@pathwayResults[[i]])
+      }
+    }
+    callNextMethod()
+  }
+)
+
+#' @rdname subsetting-methods
+#' @export
+setReplaceMethod(
+  "[[",
+  "DESummarizedExperiment",
+  function(x, i, j, ..., value) {
+    if (!missing(i)) {
+      if (i %in% names(x@deResults)) {
+        x@deResults[[i]] <- value
+        x <- updateDEmetadata(x)
+        return(x)
+      }
+      if (i %in% names(x@pathwayResults)) {
+        x@pathwayResults[[i]] <- value
+        return(x)
+      }
+    }
+    callNextMethod()
+  }
+)

--- a/R/update_de_metadata.R
+++ b/R/update_de_metadata.R
@@ -1,0 +1,13 @@
+#' Update metadata with DE result names
+#'
+#' @param x A DESummarizedExperiment.
+#'
+#' @return The updated object.
+#' @keywords internal
+#' @importFrom S4Vectors metadata metadata<-
+updateDEmetadata <- function(x) {
+  m <- S4Vectors::metadata(x)
+  m$de_results <- names(x@deResults)
+  S4Vectors::metadata(x) <- m
+  x
+}


### PR DESCRIPTION
## Summary
- add helpers to export and import differential expression results
- support merging and metadata updates for DESummarizedExperiment objects
- override subsetting and coercion methods for custom class slots

## Testing
- `R -q -e "devtools::document()"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6890ccd3f5a48330ae5c3c866e8a5aa1